### PR TITLE
Fix antiAffinity key- `run` -> `app`

### DIFF
--- a/katalog/mongo/deploy.yml
+++ b/katalog/mongo/deploy.yml
@@ -43,7 +43,7 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: run
+                    - key: app
                       operator: In
                       values:
                       - mongo


### PR DESCRIPTION
This PR fixes a potential typo/error within `mongo/deploy.yml` that may have caused pod scheduler antiAffinity to not work properly.

The pods use these labels:
```
      labels:
        app: mongo
```
and the `key` in
```
              podAffinityTerm:
                labelSelector:
                  matchExpressions:
                    - key: run
```
should refer to to the label key (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#labelselectorrequirement-v1-meta)
which is actually `app` instead of `run`.