### PR TITLE
Enable authentication and update Mongo to 4.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Following packages are included in Fury Kubernetes MongoDB katalog. All
 resources in these packages are going to be deployed in `mongo` namespace in
 your Kubernetes cluster.
 
-- [mongo](katalog/mongo): MongoDB NoSQL database. Version: **4.0.5**
+- [mongo](katalog/mongo): MongoDB NoSQL database. Version: **4.2.2**
 - [mongo-express](katalog/mongo-express): Web-based admin interface for MongoDB. Version **0.49**
 
 

--- a/katalog/mongo-express/README.md
+++ b/katalog/mongo-express/README.md
@@ -1,0 +1,45 @@
+# Fury Kubernetes Mongo Express
+
+Web-based admin interface for MongoDB.
+
+## Image repository and tag
+
+- Mongo Express image: `mongo-express:0.49`
+- Mongo Express repository: https://github.com/mongo-express/mongo-express
+
+## Requirements
+
+- Kubernetes >= `1.10.0`
+- Kustomize = `v1.0.10`
+
+## Configuration
+
+Mongo Express is deployed with following configuration:
+
+- Replica number: `1`
+- Creates a service `mongo-express` that listens on port `8081`
+- Does not create an ingress.
+
+## Deployment
+
+You can deploy MongoDB by running following command in the root of the project:
+
+```shell
+$ kustomize build | kubectl apply -f -
+```
+
+You must create an additional secret named `mongo-express-credentials` with the credentials needed to connect to `mongo`. Example command:
+
+```shell
+$ kubectl create secret generic mongo-express-credentials \
+--from-literal ME_CONFIG_MONGODB_ENABLE_ADMIN=true \
+--from-literal ME_CONFIG_MONGODB_ADMINUSERNAME=<mongodb admin username> \
+--from-literal ME_CONFIG_MONGODB_ADMINPASSWORD=<mongodb admin password> \
+--from-literal ME_CONFIG_MONGODB_AUTH_DATABASE=<mongodb user database, default is admin> \
+--from-literal ME_CONFIG_BASICAUTH_USERNAME=<if you want to enable http-auth for the web admin set this variable> \
+--from-literal ME_CONFIG_BASICAUTH_PASSWORD=<if you want to enable http-auth for the web admin set this variable>
+```
+
+## License
+
+For license details please see [LICENSE](https://sighup.io/fury/license)

--- a/katalog/mongo/README.md
+++ b/katalog/mongo/README.md
@@ -13,7 +13,6 @@ Single node [MongoDB](https://mongodb.com) cluster, ready to be expanded to mult
 - Kubernetes >= `1.10.0`
 - Kustomize = `v1.0.10`
 
-
 ## Configuration
 
 Fury distribution Mongo is deployed with following configuration:
@@ -22,9 +21,6 @@ Fury distribution Mongo is deployed with following configuration:
 - Resource limits are `1000m` for CPU and `2Gi` for memory
 - Listens on port `27017` for db and on port `9126` for metrics
 - In case of multi-node cluster automatic peer discovery and primary election
-- You must specify the username and password for the root user creating a secret `mongodb-credentials` with the following keys:
-  - `username`
-  - `password`
 
 ## Deployment
 
@@ -33,6 +29,16 @@ You can deploy MongoDB by running following command in the root of the project:
 ```shell
 $ kustomize build | kubectl apply -f -
 ```
+
+The following two secrets must also be created:
+
+1. `mongodb-credentials`: root user credentials, must have the following keys:
+    - `username`: root user username
+    - `password`: root user password
+1. `mongod-keyfile`: for replica count > 1 `mongod` uses a [keyFile](https://docs.mongodb.com/manual/core/security-internal-authentication/#internal-auth-keyfile) for authentication between replicas. The secret must have the following key:
+    - `mongod.key`: is the keyFile contents with a shared passphrase between the replicas. You can create a keyFile using the following command `openssl rand -base64 756 > mongod.key`.
+
+Please refer to mongo's [official documentation](https://docs.mongodb.com/manual/tutorial/deploy-replica-set-with-keyfile-access-control/#deploy-repl-set-with-auth) for more details on the keyFile.
 
 ## License
 

--- a/katalog/mongo/README.md
+++ b/katalog/mongo/README.md
@@ -4,10 +4,9 @@ Single node [MongoDB](https://mongodb.com) cluster, ready to be expanded to mult
 
 ## Image repository and tag
 
-* MongoDB image: `mongo:4.0.5`
-* MongoDB repository: https://github.com/mongodb/mongo
-* MongoDB documentation: https://docs.mongodb.com
-
+- MongoDB image: `mongo:4.2.2`
+- MongoDB repository: https://github.com/mongodb/mongo
+- MongoDB documentation: https://docs.mongodb.com
 
 ## Requirements
 
@@ -18,11 +17,14 @@ Single node [MongoDB](https://mongodb.com) cluster, ready to be expanded to mult
 ## Configuration
 
 Fury distribution Mongo is deployed with following configuration:
+
 - Replica number: `1`
 - Resource limits are `1000m` for CPU and `2Gi` for memory
 - Listens on port `27017` for db and on port `9126` for metrics
 - In case of multi-node cluster automatic peer discovery and primary election
-
+- You must specify the username and password for the root user creating a secret `mongodb_credentials` with the following keys:
+  - `username`
+  - `password`
 
 ## Deployment
 

--- a/katalog/mongo/README.md
+++ b/katalog/mongo/README.md
@@ -22,7 +22,7 @@ Fury distribution Mongo is deployed with following configuration:
 - Resource limits are `1000m` for CPU and `2Gi` for memory
 - Listens on port `27017` for db and on port `9126` for metrics
 - In case of multi-node cluster automatic peer discovery and primary election
-- You must specify the username and password for the root user creating a secret `mongodb_credentials` with the following keys:
+- You must specify the username and password for the root user creating a secret `mongodb-credentials` with the following keys:
   - `username`
   - `password`
 

--- a/katalog/mongo/backup.yml
+++ b/katalog/mongo/backup.yml
@@ -29,7 +29,7 @@ spec:
                     name: mongodb-credentials
                     key: password
               - name: MONGO_URI
-                value: "mongodb://$(MONGO_INITDB_ROOT_USERNAME):$(MONGO_INITDB_ROOT_PASSWORD)@mongo-0.mongo:27017,mongo-1.mongo:27017,mongo-2.mongo:27017/?replicaSet=rs0"
+                value: "mongodb+srv://$(MONGO_INITDB_ROOT_USERNAME):$(MONGO_INITDB_ROOT_PASSWORD)@mongo/?replicaSet=rs0&ssl=false"
               volumeMounts:
                 - name: backup
                   mountPath: /backup

--- a/katalog/mongo/backup.yml
+++ b/katalog/mongo/backup.yml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: mongo-backup
-              image: mongo:4.0.5
+              image: mongo:4.2.2
               imagePullPolicy: Always
               command: ["/bin/bash"]
               args:

--- a/katalog/mongo/backup.yml
+++ b/katalog/mongo/backup.yml
@@ -16,7 +16,7 @@ spec:
               command: ["/bin/bash"]
               args:
               - "-c"
-              - mongodump --uri=${MONGO_URI} --gzip --archive=/backup/mongodump.tar.gz
+              - mongodump --uri=${MONGO_URI} --gzip --archive=/backup/mongodump.archive.gz
               env:
               - name: MONGO_INITDB_ROOT_USERNAME
                 valueFrom:

--- a/katalog/mongo/backup.yml
+++ b/katalog/mongo/backup.yml
@@ -16,10 +16,20 @@ spec:
               command: ["/bin/bash"]
               args:
               - "-c"
-              - "mongodump --uri=${MONGO_URI} --gzip --archive=/backup/mongodump.tar.gz"
+              - mongodump --uri=${MONGO_URI} --gzip --archive=/backup/mongodump.tar.gz
               env:
+              - name: MONGO_INITDB_ROOT_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: mongodb-credentials
+                    key: username
+              - name: MONGO_INITDB_ROOT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: mongodb-credentials
+                    key: password
               - name: MONGO_URI
-                value: "mongodb://mongo-0.mongo:27017,mongo-1.mongo:27017,mongo-2.mongo:27017/test?replicaSet=rs0"
+                value: "mongodb://$(MONGO_INITDB_ROOT_USERNAME):$(MONGO_INITDB_ROOT_PASSWORD)@mongo-0.mongo:27017,mongo-1.mongo:27017,mongo-2.mongo:27017/?replicaSet=rs0"
               volumeMounts:
                 - name: backup
                   mountPath: /backup

--- a/katalog/mongo/deploy.yml
+++ b/katalog/mongo/deploy.yml
@@ -77,6 +77,16 @@ spec:
         env:
         - name: MONGODB_URI
           value: "mongodb://localhost:27017"
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: username
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: password
         ports:
         - name: metrics
           containerPort: 9216
@@ -92,12 +102,12 @@ spec:
         - name: MONGO_INITDB_ROOT_USERNAME
           valueFrom:
             secretKeyRef:
-              name: mongodb_credentials
+              name: mongodb-credentials
               key: username
         - name: MONGO_INITDB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: mongodb_credentials
+              name: mongodb-credentials
               key: password
         ports:
         - name: mongodb

--- a/katalog/mongo/deploy.yml
+++ b/katalog/mongo/deploy.yml
@@ -15,7 +15,7 @@ spec:
     targetPort: mongodb
   - name: metrics
     protocol: TCP
-    port: 9126
+    port: 9216
     targetPort: metrics
 ---
 apiVersion: apps/v1

--- a/katalog/mongo/deploy.yml
+++ b/katalog/mongo/deploy.yml
@@ -51,7 +51,7 @@ spec:
       terminationGracePeriodSeconds: 90
       containers:
       - name: mongo-peer-finder
-        image: quay.io/sighup/mongo-peer-finder:4.0.5_v3
+        image: quay.io/sighup/mongo-peer-finder:4.2.2_v3
         imagePullPolicy: Always
         command: ["/usr/bin/peer-finder"]
         args:
@@ -81,7 +81,7 @@ spec:
         - name: metrics
           containerPort: 9216
       - name: mongo
-        image: mongo:4.0.5
+        image: mongo:4.2.2
         imagePullPolicy: Always
         args: ["--replSet", "$(REPLICA_SET)"]
         env:
@@ -89,6 +89,16 @@ spec:
           value: "Etc/UTC"
         - name: REPLICA_SET
           value: rs0
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mongodb_credentials
+              key: username
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mongodb_credentials
+              key: password
         ports:
         - name: mongodb
           containerPort: 27017

--- a/katalog/mongo/deploy.yml
+++ b/katalog/mongo/deploy.yml
@@ -49,6 +49,21 @@ spec:
                       - mongo
                 topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 90
+      initContainers:
+        - name: change-keyfile-owner
+          image: "alpine:3.11.2"
+          command:
+            - "/bin/sh"
+          args:
+            - "-c"
+            - "cp /mongod-keyfile/mongod.key /mongod-keyfile-fixedowner/mongod.key && \
+               chown 999:999 /mongod-keyfile-fixedowner/mongod.key && \
+               chmod 0400 /mongod-keyfile-fixedowner/mongod.key"
+          volumeMounts:
+            - name: mongod-keyfile-fixedowner
+              mountPath: /mongod-keyfile-fixedowner
+            - name: mongod-keyfile
+              mountPath: /mongod-keyfile
       containers:
       - name: mongo-peer-finder
         image: quay.io/sighup/mongo-peer-finder:4.2.2_v3
@@ -67,16 +82,6 @@ spec:
           value: "rs0"
         - name: TIMEOUT
           value: "60"
-        volumeMounts:
-        - name: on-change
-          mountPath: /on-change.sh
-          subPath: on-change.sh
-      - name: mongodb-exporter
-        image: quay.io/sighup/mongodb_exporter:v0.6.2
-        imagePullPolicy: Always
-        env:
-        - name: MONGODB_URI
-          value: "mongodb://localhost:27017"
         - name: MONGO_INITDB_ROOT_USERNAME
           valueFrom:
             secretKeyRef:
@@ -87,13 +92,33 @@ spec:
             secretKeyRef:
               name: mongodb-credentials
               key: password
+        volumeMounts:
+        - name: on-change
+          mountPath: /on-change.sh
+          subPath: on-change.sh
+      - name: mongodb-exporter
+        image: quay.io/sighup/mongodb_exporter:v0.6.2
+        imagePullPolicy: Always
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: username
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: password
+        - name: MONGODB_URI
+          value: "mongodb://$(MONGO_INITDB_ROOT_USERNAME):$(MONGO_INITDB_ROOT_PASSWORD)@localhost:27017"
         ports:
         - name: metrics
           containerPort: 9216
       - name: mongo
         image: mongo:4.2.2
         imagePullPolicy: Always
-        args: ["--replSet", "$(REPLICA_SET)"]
+        args: ["--replSet", "$(REPLICA_SET)", "--keyFile", "mongod.key"]
         env:
         - name: TZ
           value: "Etc/UTC"
@@ -140,6 +165,9 @@ spec:
         volumeMounts:
         - name: mongo
           mountPath: /data/db
+        - name: mongod-keyfile-fixedowner
+          mountPath: /mongod.key
+          subPath: mongod.key
       volumes:
       - name: on-change
         configMap:
@@ -148,6 +176,11 @@ spec:
           - key: on-change.sh
             path: on-change.sh
             mode: 0755
+      - name: mongod-keyfile
+        secret:
+          secretName: mongod-keyfile
+      - name: mongod-keyfile-fixedowner
+        emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: mongo

--- a/katalog/mongo/test-read.sh
+++ b/katalog/mongo/test-read.sh
@@ -8,7 +8,7 @@ MONGO_URI="mongodb://mongo-0.mongo:27017,mongo-1.mongo:27017,mongo-2.mongo:27017
 while true; do
   now="$(date +%Y%m%d-%H%M%S)"
   echo "$now"
-  mongo --host="$MONGO_URI" --quiet --eval="db.test.find({\"key\": \"value\"})"
+  mongo --host="$MONGO_URI" --quiet -u "${MONGO_INITDB_ROOT_USERNAME}" -p "${MONGO_INITDB_ROOT_PASSWORD}" --authenticationDatabase admin --eval="db.test.find({\"key\": \"value\"})"
   echo
   sleep 5
 done

--- a/katalog/mongo/test-write.sh
+++ b/katalog/mongo/test-write.sh
@@ -9,7 +9,7 @@ MONGO_URI="mongodb://mongo-0.mongo:27017,mongo-1.mongo:27017,mongo-2.mongo:27017
 while true; do
   now="$(date +%Y%m%d-%H%M%S)"
   echo "$now"
-  mongo --host="$MONGO_URI" --quiet --eval="db.test.insert({\"key\": \"value\", \"now\": \""$now"\"}).nInserted"
+  mongo --host="$MONGO_URI" --quiet -u "${MONGO_INITDB_ROOT_USERNAME}" -p "${MONGO_INITDB_ROOT_PASSWORD}" --authenticationDatabase admin --eval="db.test.insert({\"key\": \"value\", \"now\": \""$now"\"}).nInserted"
   echo
   sleep 2
 done

--- a/katalog/mongo/test.yml
+++ b/katalog/mongo/test.yml
@@ -13,7 +13,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: test-mongo-write
-        image: mongo:4.0.5
+        image: mongo:4.2.2
         command:
         - "/bin/bash"
         - "/test-write.sh"
@@ -43,7 +43,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: test-mongo-read
-        image: mongo:4.0.5
+        image: mongo:4.2.2
         command:
         - "/bin/bash"
         - "/test-read.sh"

--- a/katalog/mongo/test.yml
+++ b/katalog/mongo/test.yml
@@ -21,6 +21,17 @@ spec:
         - name: test-write
           mountPath: /test-write.sh
           subPath: test-write.sh
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: username
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: password
       volumes:
       - name: test-write
         configMap:
@@ -47,6 +58,17 @@ spec:
         command:
         - "/bin/bash"
         - "/test-read.sh"
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: username
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: password
         volumeMounts:
         - name: test-read
           mountPath: /test-read.sh


### PR DESCRIPTION
This PR implements the needed bits for enabling authentication in mongodb and updates Mongo to v4.2.2

The authentication needs 2 new secrets to function properly:
1. A secret with a `root` username and password used to login into mongodb
1. A secret with a `keyFile` that has a shared pashphrase used by the replicas to join the replicaSet (they must use the same passphrase to be able to join)

Reference trello card: https://trello.com/c/TKslqccP 